### PR TITLE
Display logs in a new page `/logs`

### DIFF
--- a/app.js
+++ b/app.js
@@ -11,8 +11,14 @@ var webhookHandler = GitHubWebhook({ path: '/pull', secret: config.GITHUB_SECRET
 var exec = require('child_process').exec;
 
 var routes = require('./routes/index');
+var moment = require('moment');
 
 var app = express();
+var hbs = require('hbs');
+hbs.registerPartials(__dirname + '/views/partials');
+hbs.registerHelper('formatDate', (datetime) => {
+	return moment(datetime).format('MM.DD.YYYY');
+});
 
 // view engine setup
 app.set('views', path.join(__dirname, 'views'));

--- a/app.js
+++ b/app.js
@@ -31,9 +31,9 @@ app.use('/', routes);
 
 // catch 404 and forward to error handler
 app.use(function(req, res, next) {
-  var err = new Error('Not Found');
-  err.status = 404;
-  next(err);
+	var err = new Error('Not Found');
+	err.status = 404;
+	next(err);
 });
 
 // error handlers
@@ -41,23 +41,23 @@ app.use(function(req, res, next) {
 // development error handler
 // will print stacktrace
 if (app.get('env') === 'development') {
-  app.use(function(err, req, res, next) {
-    res.status(err.status || 500);
-    res.render('error', {
-      message: err.message,
-      error: err
-    });
-  });
+	app.use(function(err, req, res, next) {
+		res.status(err.status || 500);
+		res.render('error', {
+			message: err.message,
+			error: err
+		});
+	});
 }
 
 // production error handler
 // no stacktraces leaked to user
 app.use(function(err, req, res, next) {
-  res.status(err.status || 500);
-  res.render('error', {
-    message: err.message,
-    error: {}
-  });
+	res.status(err.status || 500);
+	res.render('error', {
+		message: err.message,
+		error: {}
+	});
 });
 
 webhookHandler.on('push', function (repo, data) {

--- a/public/stylesheets/style.css
+++ b/public/stylesheets/style.css
@@ -31,12 +31,15 @@ a {
 }
 
 .container {
+	width: 100%;
+	height: 100%;
+}
+
+.container.flex {
 	display: flex;
 	flex-direction: column;
 	justify-content: center;
 	align-items: center;
-	width: 100%;
-	height: 100%;
 }
 
 .center {

--- a/public/stylesheets/style.css
+++ b/public/stylesheets/style.css
@@ -1,14 +1,14 @@
 html,
 body {
-	width: 100%;
 	height: 100%;
+	width: 100%;
 }
 
 body {
+	color: #444;
 	max-width: 1000px;
 	margin: auto;
 	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen-Sans", "Ubuntu", "Cantarell", "Helvetica Neue", sans-serif;
-	color: #444;
 	font-size: 19px;
 }
 
@@ -20,7 +20,7 @@ code {
 }
 
 a {
-  color: salmon;
+	color: salmon;
 	text-decoration: none;
 	border-bottom: 1px dotted;
 }

--- a/public/stylesheets/style.css
+++ b/public/stylesheets/style.css
@@ -27,7 +27,12 @@ a {
 
 .footer {
 	margin-top: 100px;
+	margin-bottom: 30px;
 	font-size: 0.8em;
+}
+
+.flex .footer {
+	margin-bottom: 0;
 }
 
 .container {
@@ -44,4 +49,37 @@ a {
 
 .center {
 	text-align: center;
+}
+
+.logs {
+	font-family: 'Roboto Mono', monospace;
+	list-style: none;
+	line-height: 1.4;
+	font-size: 0.9em;
+}
+
+.logs--elevation {
+	color: #999;
+	margin-right: 10px;
+	display: inline-block;
+	min-width: 75px;
+	text-align: right;
+}
+
+.logs--item {
+	margin-top: 20px;
+}
+
+.logs-date {
+	margin-left: 95px;
+	font-size: 0.7em;
+	color: #aaa;
+}
+
+.goback-link {
+	margin-top: 10px;
+	margin-left: 10px;
+	display: inline-block;
+	font-size: 0.8em;
+	font-family: 'Roboto Mono', monospace;
 }

--- a/routes/index.js
+++ b/routes/index.js
@@ -24,10 +24,23 @@ router.get('/', (req, res, next) => {
 		// sum all records to get current elevation
 		res.render('index', {
 			currentMeters: meters.toFixed(0).toLocaleString(),
-			targetMeters: 100000
+			targetMeters: 100000,
+			containerClass: 'flex'
 		});
 	});
 
+});
+
+router.get('/logs', (req, res, next) => {
+	Ride.find({}, (err, rides) => {
+		if (err) {
+			throw err;
+		}
+
+		res.render('logs', {
+			rides: rides
+		});
+	});
 });
 
 module.exports = router;

--- a/routes/index.js
+++ b/routes/index.js
@@ -8,6 +8,36 @@ const target = 100000;
 
 const Ride = require('../db/rides').Ride;
 
+/**
+ * summarize total of `prop`
+ * @param  {array} rides
+ * @param  {string} prop
+ * @return {number}
+ */
+function sumThings(rides, prop) {
+	return rides.reduce((a, b) => {
+		return a + b[prop];
+	}, 0);
+}
+
+/**
+ * sort activities array by newest-first
+ * @param  {Ride} a
+ * @param  {Ride} b
+ * @return {number}
+ */
+function sortActivities(a, b) {
+	if (a.activity_id > b.activity_id) {
+		return -1;
+	}
+
+	if (a.activity_id < b.activity_id) {
+		return 1;
+	}
+
+	return 0;
+}
+
 router.get('/', (req, res, next) => {
 
 	Ride.find({}, (err, rides) => {
@@ -16,9 +46,7 @@ router.get('/', (req, res, next) => {
 			throw err;
 		}
 
-		var meters = rides.reduce((a, b) => {
-			return a + b.total_elevation_gain;
-		}, 0);
+		var meters = sumThings(rides, 'total_elevation_gain');
 
 		// get data from `rides` collection
 		// sum all records to get current elevation
@@ -37,8 +65,20 @@ router.get('/logs', (req, res, next) => {
 			throw err;
 		}
 
+		rides.sort(sortActivities);
+
+		// number of Rides
+		// total elevation gain
+		// total distance
+		const numRides = rides.length;
+		const elevations = sumThings(rides, 'total_elevation_gain').toFixed(2);
+		const distance = (sumThings(rides, 'distance') / 1000).toFixed(2);
+
 		res.render('logs', {
-			rides: rides
+			rides,
+			numRides,
+			elevations,
+			distance
 		});
 	});
 });

--- a/views/index.hbs
+++ b/views/index.hbs
@@ -18,7 +18,7 @@
 	<a href="https://github.com/armno/c">c</a> is a website made by <a href="https://armno.in.th">@armno.</a>
 	<p>
 		<small>
-    	Data collected since 07/07/2016.
+			Data collected since 07/07/2016.
 		</small>
 	</p>
 </footer>

--- a/views/index.hbs
+++ b/views/index.hbs
@@ -14,11 +14,4 @@
 	</p>
 </main>
 
-<footer class="footer center">
-	<a href="https://github.com/armno/c">c</a> is a website made by <a href="https://armno.in.th">@armno.</a>
-	<p>
-		<small>
-			Data collected since <a href="/logs">07/07/2016</a>.
-		</small>
-	</p>
-</footer>
+{{> footer}}

--- a/views/index.hbs
+++ b/views/index.hbs
@@ -18,7 +18,7 @@
 	<a href="https://github.com/armno/c">c</a> is a website made by <a href="https://armno.in.th">@armno.</a>
 	<p>
 		<small>
-			Data collected since 07/07/2016.
+			Data collected since <a href="/logs">07/07/2016</a>.
 		</small>
 	</p>
 </footer>

--- a/views/layout.hbs
+++ b/views/layout.hbs
@@ -8,7 +8,7 @@
 		<meta name="theme-color" content="#444444">
 	</head>
 	<body>
-		<main class="container">
+		<main class="container {{ containerClass }}">
 			{{{body}}}
 		</main>
 	</body>

--- a/views/layout.hbs
+++ b/views/layout.hbs
@@ -1,15 +1,15 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <title>c is for climbing</title>
+	<head>
+		<title>c is for climbing</title>
 		<meta name="viewport" content="width=device-width, initial-scale=1">
 		<link href="https://fonts.googleapis.com/css?family=Roboto+Mono" rel="stylesheet">
-    <link rel='stylesheet' href='/stylesheets/style.css'>
+		<link rel='stylesheet' href='/stylesheets/style.css'>
 		<meta name="theme-color" content="#444444">
-  </head>
-  <body>
+	</head>
+	<body>
 		<main class="container">
 			{{{body}}}
 		</main>
-  </body>
+	</body>
 </html>

--- a/views/logs.hbs
+++ b/views/logs.hbs
@@ -1,0 +1,7 @@
+<ol>
+	{{#each rides}}
+	<li>
+		{{name}}
+	</li>
+	{{/each}}
+</ol>

--- a/views/logs.hbs
+++ b/views/logs.hbs
@@ -1,7 +1,12 @@
-<ol>
+<a href="/" class="goback-link">(back)</a>
+<ol class="logs">
 	{{#each rides}}
-	<li>
+	<li class="logs--item">
+		<div class="logs-date">{{formatDate start_date}}</div>
+		<span class="logs--elevation">{{total_elevation_gain}}m</span>
 		{{name}}
 	</li>
 	{{/each}}
 </ol>
+
+{{> footer}}

--- a/views/logs.hbs
+++ b/views/logs.hbs
@@ -1,4 +1,11 @@
 <a href="/" class="goback-link">(back)</a>
+
+<div class="center">
+	{{numRides}} Rides<br>
+	{{distance}} km Distance<br>
+	{{elevations}} m Elevation
+</div>
+
 <ol class="logs">
 	{{#each rides}}
 	<li class="logs--item">

--- a/views/partials/footer.hbs
+++ b/views/partials/footer.hbs
@@ -1,0 +1,8 @@
+<footer class="footer center">
+	<a href="https://github.com/armno/c">c</a> is a website made by <a href="https://armno.in.th">@armno.</a>
+	<p>
+		<small>
+			Data collected since <a href="/logs">07/07/2016</a>.
+		</small>
+	</p>
+</footer>


### PR DESCRIPTION
fixes #14 

- create new page `/logs`, linked from home page, displays all rides record
- move footer element to a partial view
- create some handlebars helpers